### PR TITLE
Changes import to module import to pass pod lib lint

### DIFF
--- a/CleverSDK/Classes/CLVApiRequest.h
+++ b/CleverSDK/Classes/CLVApiRequest.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import "AFHTTPSessionManager.h"
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 @interface CLVApiRequest : AFHTTPSessionManager
 


### PR DESCRIPTION
This change is required to get `pod lib lint` to pass.