### PR TITLE
Dont use multipart form

### DIFF
--- a/CleverSDK.podspec
+++ b/CleverSDK.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name              = "CleverSDK"
-  s.version           = "0.1.0"
+  s.version           = "0.1.1"
   s.summary           = "A simple iOS library to access Clever Instant Login"
   s.description       = <<-DESC
   CleverSDK provides developers with a simple library to access Clever Instant Login.

--- a/CleverSDK/Classes/CLVOAuthManager.m
+++ b/CleverSDK/Classes/CLVOAuthManager.m
@@ -126,8 +126,7 @@ static NSString *const CLVServiceName = @"com.clever.CleverSDK";
     [tokens.requestSerializer setValue:[NSString stringWithFormat:@"Basic %@", encodedClientID] forHTTPHeaderField:@"Authorization"];
     NSDictionary *parameters = @{@"code": code, @"grant_type": @"authorization_code", @"redirect_uri": [self redirectUri]};
 
-    [tokens POST:@"oauth/tokens" parameters:parameters constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
-    } success:^(NSURLSessionDataTask *task, id responseObject) {
+    [tokens POST:@"oauth/tokens" parameters:parameters success:^(NSURLSessionDataTask *task, id responseObject) {
         // verify that the client id is what we expect
         if ([responseObject objectForKey:@"access_token"]) {
             [CLVOAuthManager setAccessToken:responseObject[@"access_token"]];


### PR DESCRIPTION
oauth is currently using a whitelist for multipart/form requests. Since we don't want this path to be used, remove it from the SDK too.

After successful review, will:
[ ] Tag in GH
[ ] `pod spec lint CleverSDK.podspec`
[ ] `pod trunk push CleverSDK.podspec`
