### PR TITLE
Use secure random number generation

### DIFF
--- a/CleverSDK.podspec
+++ b/CleverSDK.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name              = "CleverSDK"
-  s.version           = "0.1.2"
+  s.version           = "0.1.3"
   s.summary           = "A simple iOS library to access Clever Instant Login"
   s.description       = <<-DESC
   CleverSDK provides developers with a simple library to access Clever Instant Login.

--- a/CleverSDK/Classes/CLVOAuthManager.h
+++ b/CleverSDK/Classes/CLVOAuthManager.h
@@ -24,9 +24,9 @@ extern NSString *const CLVOAuthAuthorizeFailedNotification;
 + (void)startWithClientId:(NSString *)clientId clvLoginHandler:(CLVLoginHandler *)clvLoginHandler;
 
 /**
- This methods generates a random string.
+ This methods generates a random hex string with a given length.
  */
-+ (NSString *)generateRandomString:(int)num;
++ (NSString *)generateRandomString:(int)length;
 
 /**
  This method sets the state value used in the OAuth fow.

--- a/CleverSDK/Classes/CLVOAuthManager.m
+++ b/CleverSDK/Classes/CLVOAuthManager.m
@@ -49,12 +49,19 @@ static NSString *const CLVServiceName = @"com.clever.CleverSDK";
     manager.clvLogin = clvLoginHandler;
 }
 
-+(NSString*)generateRandomString:(int)num {
-    NSMutableString* string = [NSMutableString stringWithCapacity:32];
-    for (int i = 0; i < num; i++) {
-        [string appendFormat:@"%C", (unichar)('a' + arc4random_uniform(25))];
+
++ (NSString *)generateRandomString:(int)length {
+    NSAssert(length % 2 == 0, @"Must generate random string with even length");
+    NSMutableData *data = [NSMutableData dataWithLength:length / 2];
+    NSAssert(SecRandomCopyBytes(kSecRandomDefault, length, [data mutableBytes]) == 0, @"Failure in SecRandomCopyBytes: %d", errno);
+    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(length)];
+    const unsigned char *dataBytes = [data bytes];
+    for (int i = 0; i < length / 2; ++i)
+    {
+        [hexString appendFormat:@"%02x", (unsigned int)dataBytes[i]];
     }
-    return string;
+    return [NSString stringWithString:hexString];
+
 }
 
 + (void)setState:(NSString *)state {


### PR DESCRIPTION
This change moves us from a string generated with `arc4random_uniform` (which has issues [generating initial random numbers ](https://stackoverflow.com/a/39197677/2967120)) with [`SecRandomCopyBytes`](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes?preferredLanguage=occ).

Failure should be very uncommon for SecRandomCopyBytes, so it's probably OK to just `NSAssert` here.

The resulting string is a  hex string, rather than a lowercase alpha string. This should still have sufficient entropy (it's 512 bits). I did this to simplify the code to generate the string. Let me know if you'd suggest making this exactly backwards compatible.

