### PR TITLE
Use SFAuthenticationController on iOS 11

### DIFF
--- a/CleverSDK/Classes/CLVApiRequest.m
+++ b/CleverSDK/Classes/CLVApiRequest.m
@@ -22,6 +22,7 @@
         _sharedManager.responseSerializer = [AFJSONResponseSerializer serializer];
     });
     [_sharedManager.requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", [CLVOAuthManager accessToken]] forHTTPHeaderField:@"Authorization"];
+    [_sharedManager.requestSerializer setValue:[NSString stringWithFormat:@"0.1.3"] forHTTPHeaderField:@"X-Clever-IOS-SDK-Version"];
     return _sharedManager;
 }
 

--- a/CleverSDK/Classes/CLVLoginHandler.m
+++ b/CleverSDK/Classes/CLVLoginHandler.m
@@ -21,6 +21,8 @@
 
 @property (nonatomic, strong) NSString *districtId;
 
+@property (strong) SFAuthenticationSession *session;
+
 @end
 
 @implementation CLVLoginHandler
@@ -48,6 +50,7 @@
     NSString *state = [CLVOAuthManager generateRandomString:32];
     [CLVOAuthManager setState:state];
 
+
     NSString *urlString = [NSString stringWithFormat:@"https://clever.com/oauth/authorize?response_type=code&client_id=%@&redirect_uri=%@&state=%@",
                            [CLVOAuthManager clientId], [CLVOAuthManager redirectUri], [CLVOAuthManager state]];
 
@@ -55,23 +58,47 @@
         urlString = [NSString stringWithFormat:@"%@&district_id=%@", urlString, self.districtId];
     }
 
-    // Use SFSVC if iOS version >= 9.0
-    if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
-        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:urlString]];
+    // Xcode 9 introduces the @available macro, which we could instead use here. However, to maintain backwards
+    // compatability with earlier versions of Xcode, we use the SYSTEM_VERSION macros. As such, we can ignore
+    // warnings about it, as long as it is wrapped in macro use
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+        // Switch to native Clever app if possible
+        NSURL *cleverAppURL = [NSURL URLWithString:[NSString stringWithFormat:@"com.clever://oauth?client_id=%@&redirect_uri=%@&state=%@",
+                                                    [CLVOAuthManager clientId], [CLVOAuthManager redirectUri], [CLVOAuthManager state]]];
+        if ([[UIApplication sharedApplication] canOpenURL:cleverAppURL]) {
+            [[UIApplication sharedApplication] openURL:cleverAppURL];
+            return;
+        }
+        
+        // Fallback to SFAuthenticationSession if native Clever app not installed
+        self.session = [[SFAuthenticationSession alloc] initWithURL:[NSURL URLWithString:urlString] callbackURLScheme:NULL
+                                                  completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
+                                                      [CLVOAuthManager handleURL:callbackURL sourceApplication:@"safari" annotation:NULL];
+                                                  }];
+        [self.session start];
         return;
+    } else if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
+        SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:urlString] entersReaderIfAvailable:NO];
+        [self.parent presentViewController:svc animated:YES completion:nil];
+        return;
+    } else {
+        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:urlString]];
     }
-
-    SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:urlString] entersReaderIfAvailable:NO];
-    [self.parent presentViewController:svc animated:YES completion:nil];
 }
 
 - (void)accessTokenReceived:(NSNotification *)notification {
-    if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
+    if (@available(iOS 11.0, *)) {
+        NSLog(@"");
+    }
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
         [CLVOAuthManager callSucessHandler];
-    } else {
+    } else if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
+        // Must dismiss SFSafariViewController
         [self.parent dismissViewControllerAnimated:NO completion:^{
             [CLVOAuthManager callSucessHandler];
         }];
+    } else {
+        [CLVOAuthManager callSucessHandler];
     }
 }
 


### PR DESCRIPTION
If the sdk is running on iOS 11, uses SFAuthenticationController to
properly share OAuth state. Also checks for Clever native app and uses
that if possible. The README should also be udpated before a new
release is pushed, as these changes will require small updates to usage
of the SDK.