### PR TITLE
CleverSDK - SFSafariViewController Implementation

### DIFF
--- a/CleverSDK/CleverSDK.h
+++ b/CleverSDK/CleverSDK.h
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <SafariServices/SafariServices.h>
+
 #import "CleverLoginButton.h"
 
 #define SDK_VERSION @"iOS-2.0.0"
@@ -8,6 +10,11 @@
 + (void)startWithClientId:(NSString *)clientId LegacyIosClientId:(NSString *)legacyIosClientId RedirectURI:(NSString *)redirectUri successHandler:(void (^)(NSString *code, BOOL validState))successHandler failureHandler:(void (^)(NSString *errorMessage))failureHandler;
 
 + (void)startWithClientId:(NSString *)clientId RedirectURI:(NSString *)redirectUri successHandler:(void (^)(NSString *code, BOOL validState))successHandler failureHandler:(void (^)(NSString *errorMessage))failureHandler;
+
+// ViewController value should only be passed if you want to display SFSafariViewController.
++ (void)startWithClientId:(NSString *)clientId LegacyIosClientId:(NSString *)legacyIosClientId RedirectURI:(NSString *)redirectUri ViewController:(UIViewController *)viewController successHandler:(void (^)(NSString *code, BOOL validState))successHandler failureHandler:(void (^)(NSString *errorMessage))failureHandler;
+
++ (void)startWithClientId:(NSString *)clientId RedirectURI:(NSString *)redirectUri ViewController:(UIViewController *)viewController successHandler:(void (^)(NSString *code, BOOL validState))successHandler failureHandler:(void (^)(NSString *errorMessage))failureHandler;
 
 + (BOOL)handleURL:(NSURL *)url;
 

--- a/Example/LoginViewController.xib
+++ b/Example/LoginViewController.xib
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="LoginViewController">
             <connections>
                 <outlet property="detailLabel" destination="wdi-mE-Q1L" id="qlB-sS-FBO"/>
-                <outlet property="titleLabel" destination="ZcU-S9-VOO" id="DAp-IV-7RR"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>


### PR DESCRIPTION
Updated CleverSDK to support SFSafariViewController to be in compliance with Apple Guidelines 4.0.0.
Fixed crash on startup related to the titleLabel IBOutlet no longer existing for LoginViewController.xib.


When we submitted our app to Apple, we got caught in a compliance issue with their guidelines. They required us to make a user use an embedded browser versus the safari app, as they say it is "more insecure" to use the safari app.

Since we needed this and it seems to be required to be approved by Apple to be on their store, we just updated this SDK to support the changes. Feel free to take them :)