### PR TITLE
AOC-307 Deprecate ios-sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "15.2.0"
+      xcode: "10.1.0"
     working_directory: ~/Clever/ios-sdk
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.1.0"
+      xcode: "15.2.0"
     working_directory: ~/Clever/ios-sdk
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 CleverSDK is a simple iOS library that makes it easy for iOS developers to integrate Clever Instant Login into their application.
 You can read more about integrating Clever Instant Login in your app [here](https://dev.clever.com/docs/il-native-ios).
 
+## Project Status
+
+This SDK is no longer maintained and will be unpublished at a later date. Please see our Developer Docs for the latest information on how to integrate your app with Clever on iOS: [https://dev.clever.com/docs/il-native-ios](https://dev.clever.com/docs/il-native-ios)
+
 ## Installation
 
 CleverSDK is available through [CocoaPods](https://cocoapods.org/pods/CleverSDK).
@@ -36,7 +40,7 @@ Once your application is configured to handle your primary redirect URI you can 
                 // Additionally you're given the "validState" param which indicates that the CleverSDK initiated the login and that the
                 // state param was validated. The Clever SDK generates and validates the state param when it initiates a login.
                 // However if the login comes from the Clever Portal it will not have a state param. If your application needs extra
-                // guarantees that the user who is logging in is who they say they are you can start another login in the case that 
+                // guarantees that the user who is logging in is who they say they are you can start another login in the case that
                 // validState is false. This will result in a slower and more disruptive login experience (since users will be redirected
                 // back to Clever), but will provide an extra layer of security during the login flow. You can learn more about this here
                 // https://dev.clever.com/docs/il-design#section-protecting-against-cross-site-request-forgery-csrf
@@ -71,7 +75,8 @@ Alternatively if you know the Clever district ID of the user before the log in y
 ```
 
 ### Log in with Clever Button
-To render a [Log in with Clever Button](https://dev.clever.com/docs/identity-api#section-log-in-with-clever) you can use the provided `CleverLoginButton` class. 
+
+To render a [Log in with Clever Button](https://dev.clever.com/docs/identity-api#section-log-in-with-clever) you can use the provided `CleverLoginButton` class.
 In a `UIViewController` simply add the following code to the `viewDidLoad` method:
 
 ```obj-C
@@ -81,6 +86,7 @@ loginButton = [CleverLoginButton createLoginButton];
 
 The button is instantiated with a particular width and height.
 You can update the width of the button by calling `setWidth:` method on the button and the height will be adjusted automatically to preserve the design.
+
 ```obj-C
 [self.loginButton setWidth:300.0];
 ```
@@ -91,6 +97,7 @@ Before Clever released v2.0.0 of the `CleverSDK` Instant Login on iOS was powere
 If your application made use of these custom urls (or the old version of the `CleverSDK`) v2.0.0 of the SDK has additional features you can use to stay backwards compatible.
 
 When you instantiate the SDK you should also provide the `LegacyIosClientId` client ID (this is the client ID you used specifically in your iOS app).
+
 ```obj-C
 [CleverSDK startWithClientId:@"YOUR_CLIENT_ID" // Your Clever client ID
             LegacyIosClientId:@"YOUR_IOS_SPECIFIC_LEGACY_CLIENT_ID"
@@ -106,6 +113,7 @@ When you instantiate the SDK you should also provide the `LegacyIosClientId` cli
 
 Besides the above change, you also need to add some code to handle the iOS redirect URI.
 This is done by implementing the `application:openURL:sourceApplication:annotation:` method of the AppDelegate:
+
 ```obj-C
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
     return [CleverSDK handleURL:url];
@@ -113,8 +121,9 @@ This is done by implementing the `application:openURL:sourceApplication:annotati
 ```
 
 You'll also need to add some information to your `Info.plist` to support the custom URI schemes.
+
 1. Add `com.clever` to your [LSApplicationQueriesSchemes](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW14) so you can redirect directly to the Clever app.
-2. Add your custom clever redirect URI (should look like `clever-YOUR_CLIENT_ID`) to [URL types](https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app?language=objc), so the Clever app can open your application. 
+2. Add your custom clever redirect URI (should look like `clever-YOUR_CLIENT_ID`) to [URL types](https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app?language=objc), so the Clever app can open your application.
 
 ## Example
 


### PR DESCRIPTION
**JIRA**
[AOC-307](https://clever.atlassian.net/jira/software/c/projects/AOC/boards/268?selectedIssue=AOC-307)

**Overview**
Clever has officially launched our new SDK-less iOS login flow. We deprecate ios-sdk since it is no longer part of this flow.

**Testing:**
https://cocoapods.org/pods/CleverSDK is marked as deprecated which was the expected behavior after running the deprecate command.


**Rollout**
✅

[AOC-307]: https://clever.atlassian.net/browse/AOC-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ